### PR TITLE
enhance: reduce redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,5 +119,5 @@ export default handler(
 ```
 ### How It Works
 
-Imagegen plugin uses rewrites and redirects to proxy your image component routes, and setup a handler at the same time to snapshot your proxied image component routes and send back to the original proxy.
+Imagegen plugin proxies your image component routes, and setup a handler at the same time to snapshot your original image component HTML and send back to user end.
 

--- a/packages/next-plugin-imagegen/lib/next-config.js
+++ b/packages/next-plugin-imagegen/lib/next-config.js
@@ -2,62 +2,78 @@ const dev = process.env.NODE_ENV !== 'production'
 const instanceId = dev ? 'snapshot' : Date.now().toString(16).slice(-6)
 
 const withImagegen = (nextConfig = {}) => {
-  const jsxImagePathRegex = ':slug*.image'
+  if (dev) {
+    console.log(`\x1b[36mplugin-imagegen\x1b[0m - Develop image components at /<route>.image.${instanceId}`)
+  }
+  
+  const customConfig = (phase, { defaultConfig }, nextConfig) => {
+    nextConfig = typeof nextConfig === 'function'
+      ? nextConfig(phase, { defaultConfig })
+      : nextConfig
+    return {
+      webpack(webpackConfig, options) {
+        const { defaultLoaders } = options
+        const imageComponentExt = /\.image\.(t|j)sx?$/
 
-  if (dev)
-    console.log(
-      `\x1b[36mplugin-imagegen\x1b[0m - Develop your raw image components in /<image-page-route>.${instanceId}. e.g. /logo.image.${instanceId}`
-    )
+        webpackConfig.module.rules.push({
+          test: imageComponentExt,
+          use: [
+            {
+              loader: 'next-plugin-imagegen/loader',
+            },
+            defaultLoaders.babel,
+          ],
+        })
 
-  const customConfig = {
-    webpack(webpackConfig, options) {
-      const {defaultLoaders} = options
-      const imageComponentExt = /\.image\.(t|j)sx?$/
-
-      webpackConfig.module.rules.push({
-        test: imageComponentExt,
-        use: [
-          {
-            loader: 'next-plugin-imagegen/loader',
+        if (typeof nextConfig.webpack === 'function') {
+          return nextConfig.webpack(webpackConfig, options)
+        }
+        return webpackConfig
+      },
+      pageExtensions: [
+        'image.js',
+        'image.ts',
+        'image.jsx',
+        'image.tsx',
+      ].concat(defaultConfig.pageExtensions),
+      async redirects() {
+        const originRedirects = nextConfig.redirects
+          ? await nextConfig.redirects()
+          : []
+        return [
+          ...originRedirects,
+          // NOTE: rewriting /xxx.image to api doesn't work on dev mode, use redirects
+          dev && {
+            source: `/:slug*.image`,
+            destination: `/api/imagegen/${instanceId}/:slug*`,
+            permanent: true
           },
-          defaultLoaders.babel,
-        ]
-      })
-
-      if (typeof nextConfig.webpack === 'function') {
-        return nextConfig.webpack(webpackConfig, options)
-      }
-      return webpackConfig
-    },
-    async redirects() {
-      const originRedirects = nextConfig.redirects ? await nextConfig.redirects() : []
-      return [
-        ...originRedirects,
-        {
-          source: `/${jsxImagePathRegex}`,
-          destination: `/api/imagegen/${instanceId}/:slug*`,
-          permanent: true
-        },
-      ]
-    },
-    async rewrites() {
-      const originRewrites = nextConfig.rewrites ? await nextConfig.rewrites() : []
-      return [
-        ...originRewrites,
-        {
-          source: `/${jsxImagePathRegex}.${instanceId}`,
-          destination: `/${jsxImagePathRegex}`
-        },
-      ]
+        ].filter(Boolean)
+      },
+      async rewrites() {
+        const originRewrites = nextConfig.rewrites
+          ? await nextConfig.rewrites()
+          : []
+        return [
+          ...originRewrites,
+          // rewrites xxx.image requests to imagegen api
+          !dev && {
+            source: `/:slug*.image`,
+            destination: `/api/imagegen/${instanceId}/:slug*`,
+          },
+          // origin component snapshot
+          {
+            source: `/:slug*.image.${instanceId}`,
+            destination: `/:slug*`,
+          },
+        ].filter(Boolean)
+      },
     }
   }
 
-  return Object.assign(
-    {},
-    nextConfig,
-    customConfig,
-  )
+  return (phase, { defaultConfig }) => {
+    return customConfig(phase, { defaultConfig }, nextConfig)
+  }
 }
 
 module.exports = withImagegen
-


### PR DESCRIPTION
### Description

Use `pageExtensions` to identify `<route>.image.(j|t)sx?` as page extension, extract the `<route>` as path. 
Then use `rewrites` of next config to pipe the image component requests to imagegen api.

### Shortcut

Doesn't work with dev mode, result in 404. Guess it's sth wrong with fs routing. Fallback to redirects in dev mode now, will track this later.