### PR TITLE
build(perf): disable meta microlink query parameter

### DIFF
--- a/packages/next-plugin-imagegen/lib/default-provider.js
+++ b/packages/next-plugin-imagegen/lib/default-provider.js
@@ -26,6 +26,7 @@ const defaultProvider = (options = {}) => async function middleware(proxyUrl, re
     screenshot: true,
     force: dev,
     apiKey: apiKey || process.env.MICROLINK_TOKEN,
+    meta: false
   }
 
   const {status, data: {screenshot}} = await mql(proxyUrl, mqlOptions)


### PR DESCRIPTION
meta is enabled by default: https://microlink.io/docs/api/parameters/meta

Since this library is only targetting screenshot, disable meta could speed up the response time 🙂